### PR TITLE
feat : 게시글 삭제 기능 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ sonarqube {
 		property "sonar.profile", "Sonar way" // 소나큐브에서 적용할 프로필(분석할 수준 설정)
 		property "sonar.java.binaries", "${buildDir}/classes" // 자바 클래스 파일위치
 		property "sonar.test.inclusions", "**/*Test.java" // 코드 분석에 사용할 테스트 소스
-		property "sonar.exclusions", "**/resources/static/**, **/Q*.java, **/test/** , **/controller/** , **/domain/**" // 테스트커버리지에서 제외할 파일, 예제에선 정적 js 파일과 queryDSL Q파일 제외
+		property "sonar.exclusions", "**/resources/static/**, **/Q*.java, **/test/** , **/controller/** , **/entity/**" // 테스트커버리지에서 제외할 파일, 예제에선 정적 js 파일과 queryDSL Q파일 제외
 		property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml" // jacoco 플러그인의 결과파일
 	}
 }

--- a/src/main/java/com/hunnit_beasts/kelog/aop/Identification.java
+++ b/src/main/java/com/hunnit_beasts/kelog/aop/Identification.java
@@ -5,6 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 본인인증을 위한 어노테이션 입니다.
+ * 컨트롤러 메서드에 달아 사용하면 됩니다.
+ * 첫번째 매개변수는 token 두번째 매개변수는 @(객체)Id 이런 방식으로 사용합니다
+ * ex) userId, postId
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Identification {

--- a/src/main/java/com/hunnit_beasts/kelog/aop/IdentificationAspect.java
+++ b/src/main/java/com/hunnit_beasts/kelog/aop/IdentificationAspect.java
@@ -8,10 +8,12 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Aspect
 @Component
@@ -20,6 +22,9 @@ public class IdentificationAspect {
 
     private final ValidateService validateService;
     private final JwtUtil jwtUtil;
+    // 새로운 아이디 종류가 추가 된다면 yaml파일에 추가 하시면 됩니다.
+    @Value("${arg-types}")
+    private final Set<String> argTypes;
 
     @Before("@annotation(com.hunnit_beasts.kelog.aop.Identification)")
     public void identification(JoinPoint joinPoint) {
@@ -28,6 +33,8 @@ public class IdentificationAspect {
 
         if (parameters.containsKey("userId"))
             validateUserId(id, parameters.get("userId"));
+        else if (parameters.containsKey("postId"))
+            validatePostId(id, parameters.get("postId"));
         else
             throw new IllegalArgumentException(ErrorCode.NO_TARGET_TYPE_ERROR.getMessage());
     }
@@ -46,7 +53,7 @@ public class IdentificationAspect {
             if ("token".equals(parameterNames[i])){
                 String token = ((String) args[i]).substring(7);
                 parameters.put("id", jwtUtil.getId(token));
-            } else
+            } else if(argTypes.contains(parameterNames[i]))
                 parameters.put(parameterNames[i], (Long) args[i]);
 
         return parameters;
@@ -54,6 +61,10 @@ public class IdentificationAspect {
 
     private void validateUserId(Long id, Long userId) {
         validateService.userIdAndUserIdSameCheck(id, userId);
+    }
+
+    private void validatePostId(Long id, Long postId) {
+        validateService.userIdAndPostIdSameCheck(id, postId);
     }
 
 }

--- a/src/main/java/com/hunnit_beasts/kelog/controller/PostController.java
+++ b/src/main/java/com/hunnit_beasts/kelog/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.hunnit_beasts.kelog.controller;
 
+import com.hunnit_beasts.kelog.aop.Identification;
 import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
 import com.hunnit_beasts.kelog.dto.response.post.PostCreateResponseDTO;
 import com.hunnit_beasts.kelog.jwt.JwtUtil;
@@ -31,10 +32,10 @@ public class PostController {
 
     @PostMapping
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<PostCreateResponseDTO> addPost(@RequestHeader(value = "Authorization") String header,
+    public ResponseEntity<PostCreateResponseDTO> addPost(@RequestHeader(value = "Authorization") String token,
                                                          @RequestBody PostCreateRequestDTO dto) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(postService.postCreate(jwtUtil.getId(header), dto));
+                .body(postService.postCreate(jwtUtil.getId(token), dto));
     }
 
     @PostMapping("/like")
@@ -58,8 +59,12 @@ public class PostController {
     }
 
     @DeleteMapping("/{post-id}")
-    public void deletePost(@PathVariable(value = "post-id") Long postId) {
-        throw new UnsupportedOperationException();
+    @PreAuthorize("hasRole('USER')")
+    @Identification
+    public ResponseEntity<Long> deletePost(@RequestHeader(value = "Authorization") String token,
+                                           @PathVariable(value = "post-id") Long postId) {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(postService.postDelete(postId));
     }
 
     @DeleteMapping("/like/{post-id}")

--- a/src/main/java/com/hunnit_beasts/kelog/enumeration/system/ErrorCode.java
+++ b/src/main/java/com/hunnit_beasts/kelog/enumeration/system/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
     NOT_SAME_USERID_ERROR("CODE 6",500,"[ERROR] 본인이 아닙니다!"),
     NO_PARAMETER_ERROR("CODE 7",500,"[ERROR] 파라미터가 없습니다.!"),
     NO_USER_DATA_ERROR("CODE 8",500,"[ERROR] 유저데이터가 없습니다!"),
+    NO_POST_DATA_ERROR("CODE 9",500,"[ERROR] 게시물 데이터가 없습니다!"),
+    NOT_SAME_POST_ID_ERROR("CODE 10",500,"[ERROR] 본인의 게시물이 아닙니다!"),
     ;
 
 

--- a/src/main/java/com/hunnit_beasts/kelog/service/PostService.java
+++ b/src/main/java/com/hunnit_beasts/kelog/service/PostService.java
@@ -5,4 +5,5 @@ import com.hunnit_beasts.kelog.dto.response.post.PostCreateResponseDTO;
 
 public interface PostService {
     PostCreateResponseDTO postCreate(Long userId, PostCreateRequestDTO dto);
+    Long postDelete(Long postId);
 }

--- a/src/main/java/com/hunnit_beasts/kelog/service/ValidateService.java
+++ b/src/main/java/com/hunnit_beasts/kelog/service/ValidateService.java
@@ -3,4 +3,5 @@ package com.hunnit_beasts.kelog.service;
 public interface ValidateService {
 
     void userIdAndUserIdSameCheck(Long id, Long userId);
+    void userIdAndPostIdSameCheck(Long id, Long postId);
 }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/PostServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/PostServiceImpl.java
@@ -30,4 +30,10 @@ public class PostServiceImpl implements PostService {
         Post createdPost = postJpaRepository.save(createPostEntity);
         return postQueryDSLRepository.findPostCreateResponseDTOById(createdPost.getId());
     }
+
+    @Override
+    public Long postDelete(Long postId) {
+        postJpaRepository.deleteById(postId);
+        return postId;
+    }
 }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ValidateServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ValidateServiceImpl.java
@@ -1,19 +1,33 @@
 package com.hunnit_beasts.kelog.serviceimpl;
 
+import com.hunnit_beasts.kelog.entity.domain.Post;
 import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
+import com.hunnit_beasts.kelog.repository.jpa.PostJpaRepository;
 import com.hunnit_beasts.kelog.service.ValidateService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
 
 @Service
+@RequiredArgsConstructor
 @Log4j2
 public class ValidateServiceImpl implements ValidateService {
+
+    private final PostJpaRepository postJpaRepository;
 
     @Override
     public void userIdAndUserIdSameCheck(Long id, Long userId) {
         if(!Objects.equals(id, userId))
             throw new IllegalArgumentException(ErrorCode.NOT_SAME_USERID_ERROR.getMessage());
+    }
+
+    @Override
+    public void userIdAndPostIdSameCheck(Long id, Long postId) {
+        Post userPost = postJpaRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+        if(!userPost.getUser().getId().equals(id))
+            throw new IllegalArgumentException(ErrorCode.NOT_SAME_POST_ID_ERROR.getMessage());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,7 @@ security:
     http://127.0.0.1:3000,
     http://127.0.0.1:8000,
     http://localhost:8000
+
+arg-types:
+  userId,
+  postId

--- a/src/test/java/com/hunnit_beasts/kelog/post/PostDeleteTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/post/PostDeleteTest.java
@@ -1,0 +1,93 @@
+package com.hunnit_beasts.kelog.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.info.user.CustomUserInfoDTO;
+import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.PostType;
+import com.hunnit_beasts.kelog.enumeration.types.UserType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import com.hunnit_beasts.kelog.service.PostService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class PostDeleteTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    private Long userId;
+    private Long postId;
+    private String token;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO userDto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        userId = authService.signUp(userDto).getId();
+
+        PostCreateRequestDTO postDto = PostCreateRequestDTO.builder()
+                .title("testTitle")
+                .type(PostType.NORMAL)
+                .thumbImage("testThumbImage")
+                .isPublic(Boolean.TRUE)
+                .shortContent("testShortContent")
+                .url("testUrl")
+                .content("testContent")
+                .build();
+
+        postId = postService.postCreate(userId, postDto).getId();
+
+        CustomUserInfoDTO userInfoDTO = CustomUserInfoDTO.builder()
+                .id(userId)
+                .userId("testUserId")
+                .password("testPassword")
+                .userType(UserType.USER)
+                .build();
+
+        token = "Bearer " + jwtUtil.createToken(userInfoDTO);
+    }
+
+    @Test
+    @DisplayName("게시물 삭제")
+    void deletePost() throws Exception {
+        mockMvc.perform(delete("/posts/{post-id}", postId)
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(String.valueOf(postId)));
+    }
+}


### PR DESCRIPTION
# 📝 Pull Request 템플릿

## 📄 설명

<!-- 이 변경사항에 대한 요약과 해결된 이슈를 작성해주세요. -->
게시글 삭제 기능을 완성 하였습니다.

## ⚙️ 병합 브랜치

<!-- 이 풀 리퀘스트(PR)가 어떤 브랜치로 병합하는지 간단히 설명해주세요. -->
task/7/post Delete -> dev

## 🔗 관련 이슈

<!-- 이 이슈와 관련된 이슈 번호를 작성해주세요. -->

## ✅ 체크리스트

- [x] 어려운 부분에 대해 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 오류가 생기지 않는지 확인 했습니다.
- [ ] TODO를 해결 했습니다.
- [x] 테스트 코드를 작성하고 확인 했습니다.

## 🛠 변경 사항

<!-- 변경 사항에 대해 자세히 설명해주세요. -->
소나큐브의 커버리지에서 엔티티, 컨트롤러, 유저디테일을 제거했습니다. (미리 만들어놔서 게속 읽어옴)
본인인증 어노테이션에 사용법을 적었습니다.
aop에서 argtype을 분리 했습니다.
유저 삭제 기능을 만들었습니다.

## 📸 스크린샷

<!-- 해당되는 경우, 변경 사항을 설명하는 스크린샷을 추가해주세요. -->
![image](https://github.com/HunnitBeasts/KelogBackend/assets/119153725/6db589ad-a933-44a8-aaff-eb07cd7a279a)


## 📋 추가 정보

<!-- 이 Pull Request에 중요한 기타 정보가 있다면 여기에 작성해주세요. -->

