### PR TITLE
Task/1000/exception handler v2

### DIFF
--- a/src/main/java/com/hunnit_beasts/kelog/config/ImageConfig.java
+++ b/src/main/java/com/hunnit_beasts/kelog/config/ImageConfig.java
@@ -1,6 +1,6 @@
 package com.hunnit_beasts.kelog.config;
 
-import com.hunnit_beasts.kelog.handler.exception.UnSupportedOsException;
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -38,7 +38,7 @@ public class ImageConfig {
         else if (osName.contains("nix") || osName.contains("nux") || osName.contains("aix"))
             directory = new File(linuxUploadDirectory);
         else
-            throw new UnSupportedOsException("Unsupported operating system: " + osName);
+            throw new IllegalArgumentException(ErrorCode.NOT_SUPPORTED_OS_ERROR.getCode()+"Unsupported operating system: " + osName);
 
         if (!directory.exists()) {
             boolean created = directory.mkdirs();

--- a/src/main/java/com/hunnit_beasts/kelog/controller/TestController.java
+++ b/src/main/java/com/hunnit_beasts/kelog/controller/TestController.java
@@ -1,15 +1,18 @@
 package com.hunnit_beasts.kelog.controller;
 
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.util.Arrays;
+
+@Log4j2
 @Tag(name = "Swagger Test", description = "This is a test API")
 //@Hidden // 일단 숨겨놓고 필요에 따라 다시 올리자
 @RestController
@@ -35,5 +38,27 @@ public class TestController {
     @GetMapping("/ignore")
     public String ignore(){
         return "무시되는 API";
+    }
+
+    @PostMapping("/unsupported-operation-exception")
+    public void postUnsupportedOperationExceptionTest(){throw new UnsupportedOperationException();}
+
+    @PostMapping("/print-stacktrace-exception")
+    public void printStackTraceExceptionTest(){
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(Arrays.toString(e.getStackTrace()));
+        }
+    }
+
+    @PostMapping("/print-errorcode-stacktrace-exception")
+    public void printStackTraceErrorCodeExceptionTest(){
+
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()+ Arrays.toString(e.getStackTrace()));
+        }
     }
 }

--- a/src/main/java/com/hunnit_beasts/kelog/enumeration/system/ErrorCode.java
+++ b/src/main/java/com/hunnit_beasts/kelog/enumeration/system/ErrorCode.java
@@ -4,24 +4,44 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-    NO_POST_TYPE_ERROR("CODE 1",500,"[ERROR] PostType 이 NULL 입니다!"),
-    NO_ALARM_TYPE_ERROR("CODE 2",500,"[ERROR] AlarmType 이 NULL 입니다!"),
-    NO_SOCIAL_TYPE_ERROR("CODE 3",500,"[ERROR] SocialType 이 NULL 입니다!"),
-    NO_USER_TYPE_ERROR("CODE 4",500,"[ERROR] UserType 이 NULL 입니다!"),
-    NO_TARGET_TYPE_ERROR("CODE 5",500,"[ERROR] 두번째 매개변수 명이 잘못되었습니다!"),
-    NOT_SAME_USERID_ERROR("CODE 6",500,"[ERROR] 본인이 아닙니다!"),
-    NO_PARAMETER_ERROR("CODE 7",500,"[ERROR] 파라미터가 없습니다.!"),
-    NO_USER_DATA_ERROR("CODE 8",500,"[ERROR] 유저데이터가 없습니다!"),
-    NO_POST_DATA_ERROR("CODE 9",500,"[ERROR] 게시물 데이터가 없습니다!"),
-    NOT_SAME_POST_ID_ERROR("CODE 10",500,"[ERROR] 본인의 게시물이 아닙니다!"),
-    POST_LIKE_DUPLICATION_ERROR("CODE 14",500,"[ERROR] 이미 좋아요를 누른 게시물입니다!"),
-    NO_POST_VIEW_DATA_ERROR("CODE 12",500,"[ERROR] 조회수 정보가 없습니다."),
-    NOT_IMAGE_DATA_ERROR("CODE 13",500,"[ERROR] 요청하신 이미지가 없습니다!"),
 
-    DUPLICATION_FOLLOW_ERROR("CODE 11",500,"[ERROR] 이미 팔로우한 유저입니다!"),
-    NO_COMMENT_DATA_ERROR("CODE 20",500,"[ERROR] 댓글 데이터가 없습니다!"),
-    NOT_SAME_COMMENT_ID_ERROR("CODE 21",500,"[ERROR] 본인의 댓글이 아닙니다!"),
-    NO_FOLLOW_DATA_ERROR("CODE 22",500,"[ERROR] 팔로우 정보가 없습니다!"),
+    /*U error type: 원인을 알 수 없는 에러*/
+    OCCUR_UNKNOWN_TYPE_ERROR("CODE U-000",500,"[ERROR] 알 수 없는 에러가 발생하였습니다!"),
+
+    /*A error type: TYPE 이 NULL 인 경우 에러*/
+    NO_POST_TYPE_ERROR("CODE A-001",500,"[ERROR] PostType 이 NULL 입니다!"),
+    NO_ALARM_TYPE_ERROR("CODE A-002",500,"[ERROR] AlarmType 이 NULL 입니다!"),
+    NO_SOCIAL_TYPE_ERROR("CODE A-003",500,"[ERROR] SocialType 이 NULL 입니다!"),
+    NO_USER_TYPE_ERROR("CODE A-004",500,"[ERROR] UserType 이 NULL 입니다!"),
+
+    /*B error type: 조회한 데이터가 없을 경우 에러*/
+    NO_USER_DATA_ERROR("CODE B-001",400,"[ERROR] 유저데이터가 없습니다!"),
+    NO_POST_DATA_ERROR("CODE B-002",500,"[ERROR] 게시물 데이터가 없습니다!"),
+    NO_POST_VIEW_DATA_ERROR("CODE B-003",500,"[ERROR] 조회수 정보가 없습니다."),
+    NO_IMAGE_DATA_ERROR("CODE B-004",500,"[ERROR] 요청하신 이미지가 없습니다!"),
+    NO_COMMENT_DATA_ERROR("CODE B-005",500,"[ERROR] 댓글 데이터가 없습니다!"),
+    NO_FOLLOW_DATA_ERROR("CODE B-006",500,"[ERROR] 팔로우 정보가 없습니다!"),
+
+    /*C error type: 잘못된 입력 에러*/
+    FILE_SIZE_OVER_ERROR("CODE C-001",400,"[ERROR] 파일의 크기가 너무 큽니다!"),
+    NOT_FILE_TYPE_ERROR("CODE C-002", 400, "[ERROR] 잘못된 파일 종류입니다!"),
+    POST_LIKE_DUPLICATION_ERROR("CODE C-003",500,"[ERROR] 이미 좋아요를 누른 게시물입니다!"),
+    DUPLICATION_FOLLOW_ERROR("CODE C-004",500,"[ERROR] 이미 팔로우한 유저입니다!"),
+
+    /*D error type: 잘못된 권한 에러*/
+    NOT_SAME_USERID_ERROR("CODE D-001",500,"[ERROR] 본인이 아닙니다!"),
+    NOT_SAME_POST_ID_ERROR("CODE D-002",500,"[ERROR] 본인의 게시물이 아닙니다!"),
+    NOT_SAME_COMMENT_ID_ERROR("CODE D-003",500,"[ERROR] 본인의 댓글이 아닙니다!"),
+
+    /*E error type: 서비스 실패 에러*/
+    FILE_UPLOAD_FAILURE_ERROR("CODE E-001",500,"[ERROR] 파일을 업로드하지 못했습니다!"),
+
+    /*F error type: 서버 에러*/
+    NO_PARAMETER_ERROR("CODE F-001",500,"[ERROR] 파라미터가 없습니다!"),
+    NOT_SUPPORTED_ENDPOINT_ERROR("CODE F-002",415,"[ERROR] 정의되지 않은 기능입니다!"),
+    NOT_SUPPORTED_OS_ERROR("CODE F-003", 500, "[ERROR] 지원하지 않는 OS 입니다!"),
+    NO_TARGET_TYPE_ERROR("CODE F-004",500,"[ERROR] 두번째 매개변수 명이 잘못되었습니다!"),
+
     ;
 
 

--- a/src/main/java/com/hunnit_beasts/kelog/etc/ErrorResponseDTO.java
+++ b/src/main/java/com/hunnit_beasts/kelog/etc/ErrorResponseDTO.java
@@ -1,6 +1,9 @@
 package com.hunnit_beasts.kelog.etc;
 
-import lombok.RequiredArgsConstructor;
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
@@ -8,12 +11,26 @@ import org.springframework.web.ErrorResponse;
 
 import java.time.LocalDateTime;
 
-@RequiredArgsConstructor
+@Getter
+@AllArgsConstructor
 public class ErrorResponseDTO implements ErrorResponse {
 
     private final int status;
-    private final String errorMessage;
+    @Setter
+    private String errorMessage;
     private final LocalDateTime time;
+
+    public ErrorResponseDTO(ErrorCode errorCode){
+        this.status = errorCode.getStatus();
+        this.errorMessage = errorCode.getMessage();
+        this.time = LocalDateTime.now();
+    }
+
+    public ErrorResponseDTO(ErrorCode errorCode,String errorMessage){
+        this.status = errorCode.getStatus();
+        this.errorMessage = errorMessage;
+        this.time = LocalDateTime.now();
+    }
 
     @Override
     public HttpStatusCode getStatusCode() {
@@ -21,7 +38,7 @@ public class ErrorResponseDTO implements ErrorResponse {
     }
 
     @Override
-    public ProblemDetail getBody() {
-        return null;
-    }
+    public ProblemDetail getBody() { return null; }
+
+
 }

--- a/src/main/java/com/hunnit_beasts/kelog/handler/ControllerExceptionHandler.java
+++ b/src/main/java/com/hunnit_beasts/kelog/handler/ControllerExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.hunnit_beasts.kelog.handler;
+
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
+import com.hunnit_beasts.kelog.etc.ErrorResponseDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.List;
+
+@ControllerAdvice
+@Log4j2
+public class ControllerExceptionHandler {
+
+    private final List<ErrorCode> errorCodes;
+
+    public ControllerExceptionHandler() {
+        this.errorCodes = List.of(ErrorCode.values());
+    }
+
+    private boolean isErrorCode(String errorMessage) {
+        return errorMessage.startsWith("CODE");
+    }
+
+    private void logErrorResponse(ErrorResponseDTO dto) {
+        log.error("status : {} message : {}",dto.getStatus(), dto.getErrorMessage());
+    }
+
+    private ErrorCode findErrorCode(String code) {
+        return errorCodes.stream()
+                .filter(errorCode -> errorCode.getCode().equals(code.trim()))
+                .findFirst()
+                .orElse(ErrorCode.OCCUR_UNKNOWN_TYPE_ERROR);
+    }
+
+    private ErrorResponseDTO createErrorResponseFromMessage(String errorMessage) {
+        if (!isErrorCode(errorMessage))
+            return new ErrorResponseDTO(ErrorCode.OCCUR_UNKNOWN_TYPE_ERROR, errorMessage);
+        else {
+            if (errorMessage.length() == 10)
+                return new ErrorResponseDTO(findErrorCode(errorMessage));
+            String code = errorMessage.substring(0, 10);
+            String message = errorMessage.substring(10);
+            ErrorCode errorCode = findErrorCode(code);
+            return new ErrorResponseDTO(errorCode, message);
+        }
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponseDTO> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponseDTO dto = createErrorResponseFromMessage(e.getMessage());
+        logErrorResponse(dto);
+        return ResponseEntity.status(dto.getStatusCode()).body(dto);
+    }
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    public ResponseEntity<ErrorResponseDTO> handleUnsupportedOperationException() {
+        ErrorResponseDTO dto = new ErrorResponseDTO(ErrorCode.NOT_SUPPORTED_ENDPOINT_ERROR);
+        logErrorResponse(dto);
+        return ResponseEntity.status(dto.getStatusCode()).body(dto);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDTO> handleException(Exception e) {
+        ErrorResponseDTO dto = createErrorResponseFromMessage(e.getMessage());
+        logErrorResponse(dto);
+        return ResponseEntity.status(dto.getStatusCode()).body(dto);
+    }
+}

--- a/src/main/java/com/hunnit_beasts/kelog/handler/exception/FileUploadException.java
+++ b/src/main/java/com/hunnit_beasts/kelog/handler/exception/FileUploadException.java
@@ -1,7 +1,0 @@
-package com.hunnit_beasts.kelog.handler.exception;
-
-public class FileUploadException extends RuntimeException {
-    public FileUploadException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/hunnit_beasts/kelog/handler/exception/UnSupportedOsException.java
+++ b/src/main/java/com/hunnit_beasts/kelog/handler/exception/UnSupportedOsException.java
@@ -1,7 +1,0 @@
-package com.hunnit_beasts.kelog.handler.exception;
-
-public class UnSupportedOsException extends RuntimeException {
-    public UnSupportedOsException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/AuthServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/AuthServiceImpl.java
@@ -5,6 +5,7 @@ import com.hunnit_beasts.kelog.dto.request.user.UserLoginRequestDTO;
 import com.hunnit_beasts.kelog.dto.response.user.TokenResponseDTO;
 import com.hunnit_beasts.kelog.dto.response.user.UserCreateResponseDTO;
 import com.hunnit_beasts.kelog.entity.domain.User;
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
 import com.hunnit_beasts.kelog.jwt.JwtUtil;
 import com.hunnit_beasts.kelog.repository.jpa.UserJpaRepository;
 import com.hunnit_beasts.kelog.repository.querydsl.UserQueryDSLRepository;
@@ -29,7 +30,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public TokenResponseDTO login(UserLoginRequestDTO dto) {
         User loginUser = userJpaRepository.findByUserId(dto.getUserId())
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
 
         if(encoder.matches(dto.getPassword(), loginUser.getPassword()))
             return new TokenResponseDTO(jwtUtil.createToken(loginUser.entityToCustomUserInfoDTO()));

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/CommentServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/CommentServiceImpl.java
@@ -33,9 +33,9 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public CommentCreateResponseDTO commentCreate(Long userId, CommentCreateRequestDTO dto) {
         User commentWriter = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         Post commentedPost = postJpaRepository.findById(dto.getPostId())
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
         Comment createdCommentEntity = new Comment(dto,commentedPost,commentWriter);
         Comment createdComment = commentJpaRepository.save(createdCommentEntity);
         return commentQueryDSLRepository.findCommentCreateResponseDTOById(createdComment.getId());
@@ -50,7 +50,7 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public CommentUpdateResponseDTO commentUpdate(Long commentId, CommentUpdateRequestDTO dto) {
         CommentContent commentContent = commentContentJpaRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_COMMENT_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_COMMENT_DATA_ERROR.getCode()));
         commentContentJpaRepository.save(commentContent.commentContentUpdate(dto));
         return commentQueryDSLRepository.findCommentUpdateResponseDTOById(commentId);
     }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/CustomUserDetailsService.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.hunnit_beasts.kelog.serviceimpl;
 import com.hunnit_beasts.kelog.dto.convert.user.CustomUserDetails;
 import com.hunnit_beasts.kelog.dto.info.user.CustomUserInfoDTO;
 import com.hunnit_beasts.kelog.entity.domain.User;
+import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
 import com.hunnit_beasts.kelog.repository.jpa.UserJpaRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +24,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         User loginUser = userJpaRepository.findByUserId(userId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         return new CustomUserDetails(mapper.map(loginUser, CustomUserInfoDTO.class));
     }
 
     public CustomUserDetails loadCustomUserByUsername(Long id) throws UsernameNotFoundException {
         User loginUser = userJpaRepository.findById(id)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         return new CustomUserDetails(mapper.map(loginUser, CustomUserInfoDTO.class));
     }
 }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ImageServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ImageServiceImpl.java
@@ -4,7 +4,6 @@ import com.hunnit_beasts.kelog.config.ImageConfig;
 import com.hunnit_beasts.kelog.dto.response.image.ImageResponseDTO;
 import com.hunnit_beasts.kelog.entity.domain.Image;
 import com.hunnit_beasts.kelog.enumeration.system.ErrorCode;
-import com.hunnit_beasts.kelog.handler.exception.FileUploadException;
 import com.hunnit_beasts.kelog.repository.jpa.ImageJpaRepository;
 import com.hunnit_beasts.kelog.service.ImageService;
 import jakarta.transaction.Transactional;
@@ -41,10 +40,10 @@ public class ImageServiceImpl implements ImageService {
         String mimeType = file.getContentType();
 
         if (file.getSize() > maxSize)
-            throw new IllegalArgumentException("10MB 이하 파일만 업로드 할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorCode.FILE_SIZE_OVER_ERROR.getCode());
 
         if (!isImageFile(mimeType))
-            throw new IllegalArgumentException("이미지 파일만 업로드할 수 있습니다.");
+            throw new IllegalArgumentException(ErrorCode.NOT_FILE_TYPE_ERROR.getCode());
 
         String newFileName = generateUniqueFileName(originalFileName);
         Path filePath = Paths.get( imageConfig.getFileDirectory() + File.separator + newFileName);
@@ -52,7 +51,7 @@ public class ImageServiceImpl implements ImageService {
         try {
             Files.copy(file.getInputStream(), filePath);
         } catch (IOException e) {
-            throw new FileUploadException("File upload exception. " + Arrays.toString(e.getStackTrace()));
+            throw new IllegalArgumentException(ErrorCode.FILE_UPLOAD_FAILURE_ERROR.getCode()+"File upload exception. " + Arrays.toString(e.getStackTrace()));
         }
 
         Image saveImage = imageJpaRepository.save(new Image(file,filePath,newFileName));
@@ -63,7 +62,7 @@ public class ImageServiceImpl implements ImageService {
     @Override
     public byte[] readImage(String url) throws IOException {
         Image callImageData = imageJpaRepository.findById(url)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NOT_IMAGE_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_IMAGE_DATA_ERROR.getCode()));
         return Files.readAllBytes(Paths.get(callImageData.getFilePath()));
     }
 

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/PostServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/PostServiceImpl.java
@@ -34,7 +34,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostCreateResponseDTO postCreate(Long userId, PostCreateRequestDTO dto) {
         User creator = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(()-> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         Post createPostEntity = new Post(dto,creator);
         Post createdPost = postJpaRepository.save(createPostEntity);
         return postQueryDSLRepository.findPostCreateResponseDTOById(createdPost.getId());
@@ -49,14 +49,14 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostLikeResponseDTO addPostLike(Long userId, PostLikeRequestDTO dto) {
         User user = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         Post post = postJpaRepository.findById(dto.getPostId())
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
 
-        if (likedPostJpaRepository.existsById(new LikedPostId(user, post)))
-            throw new IllegalArgumentException(ErrorCode.POST_LIKE_DUPLICATION_ERROR.getMessage());
-        else {
-            LikedPost likedPost = likedPostJpaRepository.save(new LikedPost(user, post));
+        if(likedPostJpaRepository.existsById(new LikedPostId(user,post)))
+            throw new IllegalArgumentException(ErrorCode.POST_LIKE_DUPLICATION_ERROR.getCode());
+        else{
+            LikedPost likedPost = likedPostJpaRepository.save(new LikedPost(user,post));
             return new PostLikeResponseDTO(likedPost);
         }
     }
@@ -64,11 +64,11 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostViewCntResponseDTO plusViewCnt(Long postId) {
         Post plusViewCntPost = postJpaRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
         PostViewCntId thisPostsViewCnt = new PostViewCntId(plusViewCntPost.getId());
         if(postViewCntJpaRepository.existsById(thisPostsViewCnt)){
             PostViewCnt postViewCnt = postViewCntJpaRepository.findById(thisPostsViewCnt)
-                    .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_VIEW_DATA_ERROR.getMessage()));
+                    .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_VIEW_DATA_ERROR.getCode()));
             postViewCntJpaRepository.save(postViewCnt.plusViewCnt());
         }else
             postViewCntJpaRepository.save(new PostViewCnt(plusViewCntPost));
@@ -78,21 +78,21 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostLikeResponseDTO deletePostLike(Long userId, Long postId) {
         User user = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         Post post = postJpaRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
         LikedPostId likedPostId = new LikedPostId(user, post);
         if (likedPostJpaRepository.existsById(likedPostId))
             likedPostJpaRepository.deleteById(likedPostId);
         else
-            throw new IllegalArgumentException(ErrorCode.POST_LIKE_DUPLICATION_ERROR.getMessage());
-        return new PostLikeResponseDTO(userId,postId);  
+            throw new IllegalArgumentException(ErrorCode.POST_LIKE_DUPLICATION_ERROR.getCode());
+        return new PostLikeResponseDTO(userId,postId);
     }
-  
+
     @Override
     public SeriesCreateResponseDTO createSeries(Long userId, SeriesCreateRequestDTO dto) {
         User user = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         Series series = seriesJpaRepository.save(new Series(user, dto));
         return new SeriesCreateResponseDTO(series);
     }
@@ -100,9 +100,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public RecentViewCreateResponseDTO recentViewAdd(Long userId, Long postId) {
       User user = userJpaRepository.findById(userId)
-              .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+              .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
       Post post = postJpaRepository.findById(postId)
-              .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+              .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
 
       RecentPostId recentPostId = new RecentPostId(userId,postId);
 
@@ -119,7 +119,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostUpdateResponseDTO postUpdate(Long postId, PostUpdateRequestDTO dto) {
         Post post = postJpaRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
         Post updatedPost = postJpaRepository.save(post.changePost(dto));
         return postQueryDSLRepository.findPostUpdateResponseDTOById(updatedPost.getId());
     }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/UserServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/UserServiceImpl.java
@@ -23,11 +23,11 @@ public class UserServiceImpl implements UserService {
     @Override
     public FollowIngResponseDTO following(Long userId, FollowIngRequestDTO dto) {
         User follower = userJpaRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         User followee = userJpaRepository.findById(dto.getFollowee())
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_USER_DATA_ERROR.getCode()));
         if(followerJpaRepository.existsById(new FollowerId(follower,followee)))
-            throw new IllegalArgumentException(ErrorCode.DUPLICATION_FOLLOW_ERROR.getMessage());
+            throw new IllegalArgumentException(ErrorCode.DUPLICATION_FOLLOW_ERROR.getCode());
         Follower follow = followerJpaRepository.save(new Follower(follower,followee));
         return new FollowIngResponseDTO(follow);
     }
@@ -38,7 +38,7 @@ public class UserServiceImpl implements UserService {
         if(followerJpaRepository.existsById(followerId))
             followerJpaRepository.deleteById(followerId);
         else
-            throw new IllegalArgumentException(ErrorCode.NO_FOLLOW_DATA_ERROR.getMessage());
+            throw new IllegalArgumentException(ErrorCode.NO_FOLLOW_DATA_ERROR.getCode());
         return new FollowDeleteResponseDTO(follower, followee);
     }
 }

--- a/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ValidateServiceImpl.java
+++ b/src/main/java/com/hunnit_beasts/kelog/serviceimpl/ValidateServiceImpl.java
@@ -23,22 +23,22 @@ public class ValidateServiceImpl implements ValidateService {
     @Override
     public void userIdAndUserIdSameCheck(Long id, Long userId) {
         if(!Objects.equals(id, userId))
-            throw new IllegalArgumentException(ErrorCode.NOT_SAME_USERID_ERROR.getMessage());
+            throw new IllegalArgumentException(ErrorCode.NOT_SAME_USERID_ERROR.getCode());
     }
 
     @Override
     public void userIdAndPostIdSameCheck(Long id, Long postId) {
         Post userPost = postJpaRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_POST_DATA_ERROR.getCode()));
         if(!userPost.getUser().getId().equals(id))
-            throw new IllegalArgumentException(ErrorCode.NOT_SAME_POST_ID_ERROR.getMessage());
+            throw new IllegalArgumentException(ErrorCode.NOT_SAME_POST_ID_ERROR.getCode());
     }
 
     @Override
     public void userIdAndCommentIdSameCheck(Long id, Long commentId) {
         Comment comment = commentJpaRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_COMMENT_DATA_ERROR.getMessage()));
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.NO_COMMENT_DATA_ERROR.getCode()));
         if(!comment.getUser().getId().equals(id))
-            throw new IllegalArgumentException(ErrorCode.NOT_SAME_COMMENT_ID_ERROR.getMessage());
+            throw new IllegalArgumentException(ErrorCode.NOT_SAME_COMMENT_ID_ERROR.getCode());
     }
 }

--- a/src/test/java/com/hunnit_beasts/kelog/exception/CreateCommentExceptionTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/CreateCommentExceptionTest.java
@@ -1,0 +1,115 @@
+package com.hunnit_beasts.kelog.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.info.user.CustomUserInfoDTO;
+import com.hunnit_beasts.kelog.dto.request.comment.CommentCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.PostType;
+import com.hunnit_beasts.kelog.enumeration.types.UserType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import com.hunnit_beasts.kelog.service.PostService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class CreateCommentExceptionTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    private Long userId;
+    private Long postId;
+    private String token;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO userDto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        Long userId = authService.signUp(userDto).getId();
+
+        PostCreateRequestDTO postDto = PostCreateRequestDTO.builder()
+                .title("testTitle")
+                .type(PostType.NORMAL)
+                .thumbImage("testThumbImage")
+                .isPublic(Boolean.TRUE)
+                .shortContent("testShortContent")
+                .url("testUrl")
+                .content("testContent")
+                .build();
+
+        postId = postService.postCreate(userId, postDto).getId();
+
+        UserCreateRequestDTO commentWriter = UserCreateRequestDTO.builder()
+                .userId("testCommentWriterId")
+                .password("testCommentWriterPassword")
+                .nickname("testCommentWriterNickname")
+                .briefIntro("testBriefIntro")
+                .email("testCommentWriterEmail")
+                .build();
+
+        this.userId = authService.signUp(commentWriter).getId();
+
+        CustomUserInfoDTO userInfoDTO = CustomUserInfoDTO.builder()
+                .id(this.userId)
+                .userId("testUserId")
+                .password("testPassword")
+                .userType(UserType.USER)
+                .build();
+
+        token = "Bearer " + jwtUtil.createToken(userInfoDTO);
+    }
+
+    @Test
+    @DisplayName("댓글 작성")
+    void createComment() throws Exception {
+        CommentCreateRequestDTO dto = CommentCreateRequestDTO.builder()
+                .postId(postId+1)
+                .content("testCommentContent")
+                .build();
+
+        String jsonContent = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/comments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("errorMessage").value("[ERROR] 게시물 데이터가 없습니다!"))
+                .andExpect(jsonPath("time").isString())
+                .andReturn();
+    }
+}

--- a/src/test/java/com/hunnit_beasts/kelog/exception/ImageUploadExceptionTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/ImageUploadExceptionTest.java
@@ -1,0 +1,133 @@
+package com.hunnit_beasts.kelog.exception;
+
+import com.hunnit_beasts.kelog.dto.info.user.CustomUserInfoDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.UserType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class ImageUploadExceptionTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    private String token;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO userDto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        Long userId = authService.signUp(userDto).getId();
+
+        CustomUserInfoDTO userInfoDTO = CustomUserInfoDTO.builder()
+                .id(userId)
+                .userId("testUserId")
+                .password("testPassword")
+                .userType(UserType.USER)
+                .build();
+
+        token = "Bearer " + jwtUtil.createToken(userInfoDTO);
+    }
+
+    @Test
+    @DisplayName("이미지 파일 10MB 초과 시 예외 테스트")
+    void imageUploadSizeException() throws Exception {
+
+        String fileName = "dummyfile.txt";
+        long size = 10 * 1024 * 1025; //10mb 크기를 초과하는 파일 사이즈 정의
+
+        File file = new File(fileName);
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+
+            byte[] buffer = new byte[1024 * 1025];
+
+            for (int i = 0; i < buffer.length; i++) {
+                buffer[i] = 'A';
+            }
+            long bytesWritten = 0;
+            while (bytesWritten < size) {
+                fos.write(buffer);
+                bytesWritten += buffer.length;
+            }
+        }
+
+        Path filePath = Paths.get(fileName);
+
+        try (FileInputStream fis = new FileInputStream(filePath.toFile())) {
+            MockMultipartFile multipartFile = new MockMultipartFile(
+                    "multipartFile",
+                    fileName,
+                    "image/jpg",
+                    fis);
+
+            mockMvc.perform(multipart("/images")
+                            .file(multipartFile)
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .header("Authorization", token)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(jsonPath("errorMessage").value("[ERROR] 파일의 크기가 너무 큽니다!"))
+                    .andExpect(jsonPath("time").isString());
+
+            Files.delete(filePath);
+        }
+    }
+
+    @Test
+    @DisplayName("이미지 파일이 아닌 파일 업로드 예외 테스트")
+    void imageUploadTypeException() throws Exception {
+
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "multipartFile",
+                "test.txt",
+                "", //오류를 발생시키는 부분. contentType 이 비어있음
+                "testImage".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/images")
+                        .file(multipartFile)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("errorMessage").value("[ERROR] 잘못된 파일 종류입니다!"))
+                .andExpect(jsonPath("time").isString());
+
+    }
+}

--- a/src/test/java/com/hunnit_beasts/kelog/exception/LoginIllegalArgumentExceptionTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/LoginIllegalArgumentExceptionTest.java
@@ -1,0 +1,74 @@
+package com.hunnit_beasts.kelog.exception;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserLoginRequestDTO;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class LoginIllegalArgumentExceptionTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO dto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        authService.signUp(dto);
+    }
+
+    @Test
+    @DisplayName("login IllegalArgumentException 예외 테스트")
+    public void exceptionHandleTest1() throws Exception {
+
+        UserLoginRequestDTO dto = UserLoginRequestDTO.builder()
+                .userId("testUserId1") //예외 발생부분
+                .password("testPassword")
+                .build();
+
+        String jsonContent = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("errorMessage").value("[ERROR] 유저데이터가 없습니다!"))
+                .andExpect(jsonPath("time").isString())
+                .andReturn();
+    }
+
+}

--- a/src/test/java/com/hunnit_beasts/kelog/exception/PrintErrorCodeAndStackTraceTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/PrintErrorCodeAndStackTraceTest.java
@@ -1,0 +1,79 @@
+package com.hunnit_beasts.kelog.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.PostType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class PrintErrorCodeAndStackTraceTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO dto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        authService.signUp(dto);
+    }
+
+    @Test
+    @DisplayName("에러 코드 및 스택 트레이스 출력 테스트")
+    public void printErrorCodeStackTrace() throws Exception {
+
+        PostCreateRequestDTO dto = PostCreateRequestDTO.builder()
+                .title("testTitle")
+                .type(PostType.NORMAL)
+                .thumbImage("testThumbImage")
+                .isPublic(Boolean.TRUE)
+                .shortContent("testShortContent")
+                .url("testUrl")
+                .content("testContent")
+                .build();
+
+        String jsonContent = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/api/print-errorcode-stacktrace-exception")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().is4xxClientError())
+                .andExpect(MockMvcResultMatchers.jsonPath("errorMessage").isString())
+                .andExpect(MockMvcResultMatchers.jsonPath("time").isString())
+                .andReturn();
+
+    }
+}

--- a/src/test/java/com/hunnit_beasts/kelog/exception/PrintStackTraceTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/PrintStackTraceTest.java
@@ -1,0 +1,79 @@
+package com.hunnit_beasts.kelog.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.PostType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class PrintStackTraceTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO dto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        authService.signUp(dto);
+    }
+
+    @Test
+    @DisplayName("스택 트레이스 출력 테스트")
+    public void printStackTrace() throws Exception {
+
+        PostCreateRequestDTO dto = PostCreateRequestDTO.builder()
+                .title("testTitle")
+                .type(PostType.NORMAL)
+                .thumbImage("testThumbImage")
+                .isPublic(Boolean.TRUE)
+                .shortContent("testShortContent")
+                .url("testUrl")
+                .content("testContent")
+                .build();
+
+        String jsonContent = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/api/print-stacktrace-exception")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().is5xxServerError())
+                .andExpect(MockMvcResultMatchers.jsonPath("errorMessage").isString())
+                .andExpect(MockMvcResultMatchers.jsonPath("time").isString())
+                .andReturn();
+
+    }
+}

--- a/src/test/java/com/hunnit_beasts/kelog/exception/UnsupportedExceptionTest.java
+++ b/src/test/java/com/hunnit_beasts/kelog/exception/UnsupportedExceptionTest.java
@@ -1,0 +1,75 @@
+package com.hunnit_beasts.kelog.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hunnit_beasts.kelog.dto.request.post.PostCreateRequestDTO;
+import com.hunnit_beasts.kelog.dto.request.user.UserCreateRequestDTO;
+import com.hunnit_beasts.kelog.enumeration.types.PostType;
+import com.hunnit_beasts.kelog.jwt.JwtUtil;
+import com.hunnit_beasts.kelog.service.AuthService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class UnsupportedExceptionTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(){
+        UserCreateRequestDTO dto = UserCreateRequestDTO.builder()
+                .userId("testUserId")
+                .password("testPassword")
+                .nickname("testNickname")
+                .briefIntro("testBriefIntro")
+                .email("testEmail")
+                .build();
+
+        authService.signUp(dto);
+    }
+
+    @Test
+    @DisplayName("Unsupported 예외 테스트")
+    public void exceptionHandleTest() throws Exception {
+
+        PostCreateRequestDTO dto = PostCreateRequestDTO.builder()
+                .title("testTitle")
+                .type(PostType.NORMAL)
+                .thumbImage("testThumbImage")
+                .isPublic(Boolean.TRUE)
+                .shortContent("testShortContent")
+                .url("testUrl")
+                .content("testContent")
+                .build();
+
+        String jsonContent = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(post("/api/unsupported-operation-exception")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(jsonContent))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+    }
+}


### PR DESCRIPTION
# 📝 Pull Request 템플릿

## 📄 설명

<!-- 이 변경사항에 대한 요약과 해결된 이슈를 작성해주세요. -->
1. exception handler 를 작성하였습니다
2. errorcode 종류에 따라 정리하였습니다
3. exception class 두개를 삭제하였습니다
4. serviceImpl 의 코드 들 중 에러 메시지를 출력하는 부분을 수정하였습니다

## ⚙️ 병합 브랜치

<!-- 이 풀 리퀘스트(PR)가 어떤 브랜치로 병합하는지 간단히 설명해주세요. -->
task/1000/exception handler v2 -> dev

## 🔗 관련 이슈

<!-- 이 이슈와 관련된 이슈 번호를 작성해주세요. -->

## ✅ 체크리스트

- [x] 어려운 부분에 대해 주석을 추가했습니다.
- [ ] 문서에 변경 사항을 반영했습니다.
- [x] 오류가 생기지 않는지 확인 했습니다.
- [ ] TODO를 해결 했습니다.
- [x] 테스트 코드를 작성하고 확인 했습니다.

## 🛠 변경 사항

<!-- 변경 사항에 대해 자세히 설명해주세요. -->
1. 이제부터 exception handler 를 통해 컨트롤러의 에러를 전역적으로 처리할수 있습니다
2. 모든 에러에 대응 하는 에러 코드를 작성하고 원인을 찾지 못한 에러는 기본으로 설정한 에러가 뜨도록 설정하였습니다
3. ErrorResponseDTO 의 생성자를 수정하였습니다
## 📸 스크린샷

<!-- 해당되는 경우, 변경 사항을 설명하는 스크린샷을 추가해주세요. -->

## 📋 추가 정보

<!-- 이 Pull Request에 중요한 기타 정보가 있다면 여기에 작성해주세요. -->

